### PR TITLE
add an error log on yaml parse failure

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,5 +2,6 @@
 
 ## devel
 
+* add error logging for failed yaml parses
 * add verbose flag to enable debug output
 * add current logs for all mapi container pods

--- a/okd_camgi/interfaces.py
+++ b/okd_camgi/interfaces.py
@@ -83,7 +83,13 @@ class MustGather:
                     if filename == f'{podname}.yaml':
                         logging.debug(f'loading {filename}')
                         with open(os.path.join(pods_path, podname, filename)) as man_file:
-                            resource = yaml.load(man_file.read(), Loader=yaml.FullLoader)
+                            try:
+                                resource = yaml.load(man_file.read(), Loader=yaml.FullLoader)
+                            except yaml.YAMLError as ex:
+                                # if the yaml is bad, log an error and ignore the manifest
+                                mark = ex.problem_mark
+                                logging.error(f'unable to parse {filename}, error at line:{mark.line+1} col:{mark.column+1}')
+                                resource = None
                     # sub-directories are containers within the pod, check to see if log files exist
                     elif os.path.exists(currentlog):
                         logging.debug(f'found container logs for {filename}, opening {currentlog}')
@@ -120,7 +126,13 @@ class MustGather:
             return None
         logging.debug(f'loading {group}/{kind} yaml from {man_path}')
         with open(man_path) as man_file:
-            resource = yaml.load(man_file.read(), Loader=yaml.FullLoader)
+            try:
+                resource = yaml.load(man_file.read(), Loader=yaml.FullLoader)
+            except yaml.YAMLError as ex:
+                # if the yaml is bad, log an error and ignore the manifest
+                mark = ex.problem_mark
+                logging.error(f'unable to parse {man_path}, error at line:{mark.line+1} col:{mark.column+1}')
+                return None
             return Resource(resource)
 
     def resources(self, kind, group=None, namespace=None):


### PR DESCRIPTION
This change emits an error log showing the line and column of the error
in the yaml file.

fixes #2 

output looks like this:
```
ERROR:root:unable to parse must-gather/foo/cluster-scoped-resources/core/nodes/foo-master-1.yaml, error at line:430 col:1
```

this does not halt processing