### PR TITLE
convert nav menu to use vuejs

### DIFF
--- a/okd_camgi/templates/index.html
+++ b/okd_camgi/templates/index.html
@@ -23,38 +23,29 @@ table {
 </style>
   </head>
   <body>
-    <div class="container-fluid">
-      <!--
-      <div class="row-fluid border-bottom">
-        <div class="col">
-          <div id="top-tray" class="mb-1">
-            <span class="fw-bold">{{ '{{ message }}' }}</span>
-          </div>
-        </div>
-      </div>
-      -->
+    <div id="app" class="container-fluid">
       <div class="row mt-2">
         <div class="col-2" id="nav-col">
           <div class="list-group">
-            <a href="#" id="summary" class="list-group-item list-group-item-action">Summary</a>
-            <a href="#" id="mapipods" class="list-group-item list-group-item-action">Machine API</a>
-            <a href="#" id="mcopods" class="list-group-item list-group-item-action">Machine Config</a>
-            <a href="#" id="clusterautoscalers" class="list-group-item list-group-item-action">ClusterAutoscalers</a>
-            <a href="#" id="machineautoscalers" class="list-group-item list-group-item-action">MachineAutoscalers</a>
-            <a href="#" id="machines" class="list-group-item list-group-item-action">Machines
+            <a href="#" v-on:click="changeContent('summary')" class="list-group-item list-group-item-action">Summary</a>
+            <a href="#" v-on:click="changeContent('mapipods')" class="list-group-item list-group-item-action">Machine API</a>
+            <a href="#" v-on:click="changeContent('mcopods')" class="list-group-item list-group-item-action">Machine Config</a>
+            <a href="#" v-on:click="changeContent('clusterautoscalers')" class="list-group-item list-group-item-action">ClusterAutoscalers</a>
+            <a href="#" v-on:click="changeContent('machineautoscalers')" class="list-group-item list-group-item-action">MachineAutoscalers</a>
+            <a href="#" v-on:click="changeContent('machines')" class="list-group-item list-group-item-action">Machines
               {% if machines.notrunning|length > 0 %}<span class="badge bg-danger float-right">{{ machines.notrunning|length }}</span>{% endif %}
             </a>
-            <a href="#" id="nodes" class="list-group-item list-group-item-action">Nodes
+            <a href="#" v-on:click="changeContent('nodes')" class="list-group-item list-group-item-action">Nodes
               {% if nodes.notready|length > 0 %}<span class="badge bg-danger float-right">{{ nodes.notready|length }}</span>{% endif %}
             </a>
-            <a href="#" id="csrs" class="list-group-item list-group-item-action">CSRs
+            <a href="#" v-on:click="changeContent('csrs')" class="list-group-item list-group-item-action">CSRs
               {% if csrs.denied_or_failed|length > 0 %}<span class="badge bg-danger float-right">{{ csrs.denied_or_failed|length }}</span>{% endif %}
               {% if csrs.pending|length > 0 %}<span class="badge bg-warning float-right">{{ csrs.pending|length }}</span>{% endif %}
             </a>
           </div>
         </div>
         <div class="col-10">
-          <div id="main-content" class="overflow-auto"></div>
+          <div id="main-content" class="overflow-auto"><span v-html="content"></span></div>
         </div>
       </div>
     </div>
@@ -261,7 +252,7 @@ table {
             class="accordion-button collapsed p-2"
             type="button"
             data-bs-toggle="collapse"
-            data-bs-target="#collapse-{{ pod.metadata.name|replace(".", "-") }}" 
+            data-bs-target="#collapse-{{ pod.metadata.name|replace(".", "-") }}"
             aria-expanded="false"
             aria-controls="collapse-{{ pod.metadata.name|replace(".", "-") }}">
           <strong>{{ pod.metadata.name }}</strong>
@@ -305,7 +296,7 @@ table {
   </div>
   {% endfor %}
 </data>
- 
+
 <data id="mcopods-data">
   <h1>Machine Config Pods</h1>
   {% for pod in mcopods %}
@@ -316,7 +307,7 @@ table {
             class="accordion-button collapsed p-2"
             type="button"
             data-bs-toggle="collapse"
-            data-bs-target="#collapse-{{ pod.metadata.name|replace(".", "-") }}" 
+            data-bs-target="#collapse-{{ pod.metadata.name|replace(".", "-") }}"
             aria-expanded="false"
             aria-controls="collapse-{{ pod.metadata.name|replace(".", "-") }}">
           <strong>{{ pod.metadata.name }}</strong>
@@ -360,7 +351,7 @@ table {
   </div>
   {% endfor %}
 </data>
- 
+
 {% for data in accordiondata %}
 <data id="{{ data.cssid }}-data">
   <h1>{{ data.name }}</h1>
@@ -372,7 +363,7 @@ table {
             class="accordion-button collapsed p-2 {{ item.statusclasses }}"
             type="button"
             data-bs-toggle="collapse"
-            data-bs-target="#collapse-{{ item.metadata.name|replace(".", "-") }}" 
+            data-bs-target="#collapse-{{ item.metadata.name|replace(".", "-") }}"
             aria-expanded="false"
             aria-controls="collapse-{{ item.metadata.name|replace(".", "-") }}">
           {{ item.metadata.name }}
@@ -395,46 +386,30 @@ table {
   <!-- bootstrap -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
   <!-- vuejs -->
-  <!--
   <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
-  -->
 
 <script>
-  // a vue stub, in case i want to use it later
-  /*
+// main vue entry point
 var app = new Vue({
-  el: '#top-tray',
+  el: '#app',
   data: {
-    message: '{{ basename }}'
+    content: ''
+  },
+  methods: {
+    changeContent: function(target) {
+        let newdata = document.getElementById(target + '-data')
+        this.content = newdata.innerHTML
+    }
   }
 })
- */
 
+// adjust the content window size
+// TODO add this to a resize function
 var maincontent = document.getElementById('main-content')
 maincontent.style.height = window.innerHeight - 10
 
-/* datalist associates a data element with its button on the side nav */
-var datalist = [
-  'mapipods',
-  'mcopods',
-  'clusterautoscalers',
-  'machineautoscalers',
-  'machines',
-  'nodes',
-  'csrs',
-  'summary',
-]
-datalist.forEach(function (element) {
-    let anchor = document.getElementById(element)
-    if (anchor != undefined) {
-        anchor.onclick = function () {
-            let data = document.getElementById(element + '-data')
-            maincontent.innerHTML = data.innerHTML
-        }
-    }
-})
-var summary = document.getElementById('summary')
-summary.click()
+// set the summary page
+app.changeContent('summary')
 </script>
   </body>
 </html>


### PR DESCRIPTION
this change wraps the entire contents in a vue app and converts the nav
menu to use vue for switching the main content. this lightens the
developer toil when adding new sections as now there is only one main
place to add the button, and then one place to add the data.

it's not clear if this change has sped up the rendering.

this is related to #6 , perhaps converting more of the app to use vue for loading could be helpful.