### PR TITLE
Add possibility to open mg tar archives from OCP CI

### DIFF
--- a/okd_camgi/interfaces.py
+++ b/okd_camgi/interfaces.py
@@ -1,7 +1,6 @@
 '''Interfaces into the must gather artifacts and data.'''
 from collections import UserDict
 from copy import deepcopy
-import json
 import logging
 import os.path
 


### PR DESCRIPTION
Adds cli '--tar' flag for being able to generate
investigator report without prior archive unpacking.
With this flag archive located by 'path'
argument will be attempted to unpack into temporary
directory.

p.s some unused imports was removed