### PR TITLE
improve directory detection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## devel
 
+* improve directory detection and error reporting for must-gathers
 * add a --tar flag to allow processing of tar files
 * add a fix for ClusterAutoscaler with no defined resourceLimits
 


### PR DESCRIPTION
This change makes it so that okd-camgi will attempt to determine if the
path specified is a proper must-gather, it will also attempt to look
into deeper directories if there is only a single subdir in the top
path.

fixes #27 