### PR TITLE
add more machineset data

### DIFF
--- a/okd_camgi/contexts.py
+++ b/okd_camgi/contexts.py
@@ -297,6 +297,7 @@ class IndexContext(UserDict):
         mcopods = sorted([PodContext(pod) for pod in mustgather.pods('openshift-machine-config-operator')], key=lambda p: p['metadata']['name'])
         machineautoscalers = [ResourceContext(machineautoscaler) for machineautoscaler in mustgather.machineautoscalers]
         clusterautoscalers = [ClusterAutoscalerContext(clusterautoscaler) for clusterautoscaler in mustgather.clusterautoscalers]
+        machinesets = [MachineSetContext(machineset) for machineset in mustgather.machinesets]
         machines = MachinesContext([MachineContext(machine) for machine in mustgather.machines])
         nodes = NodesContext([NodeContext(node) for node in mustgather.nodes])
         csrs = CSRsContext(
@@ -320,6 +321,7 @@ class IndexContext(UserDict):
             'accordiondata': [
                 AccordionDataContext('ClusterAutoscalers', clusterautoscalers),
                 AccordionDataContext('MachineAutoscalers', machineautoscalers),
+                AccordionDataContext('MachineSets', machinesets),
                 AccordionDataContext('Machines', machines),
                 AccordionDataContext('Nodes', nodes),
                 AccordionDataContext('CSRs', csrs),
@@ -332,8 +334,8 @@ class IndexContext(UserDict):
             'highlight_css': HtmlFormatter().get_style_defs('.highlight'),
             'machineautoscalers': machineautoscalers,
             'machines': machines,
-            'machinesets': [MachineSetContext(machineset) for machineset in mustgather.machinesets],
-            'machinesets_participating': [ msc for msc in [MachineSetContext(machineset) for machineset in mustgather.machinesets] if msc.autoscaler_min],
+            'machinesets': machinesets,
+            'machinesets_participating': [ msc for msc in machinesets if msc.autoscaler_min],
             'mapipods': mapipods,
             'mcopods': mcopods,
             'nodes': nodes,

--- a/okd_camgi/templates/index.html
+++ b/okd_camgi/templates/index.html
@@ -172,14 +172,16 @@ table {
         <thead>
           <tr>
             <th scope="col">Name</th>
-            <th scope="col">Min Replicas</th>
-            <th scope="col">Max Replicas</th>
+            <th scope="col">Current Replicas</th>
+            <th scope="col">Min</th>
+            <th scope="col">Max</th>
           </tr>
         </thead>
         <tbody>
           {% for machineset in machinesets_participating %}
           <tr>
             <th scope="col">{{ machineset.metadata.name }}</th>
+            <td>{{ machineset.spec.replicas }}</td>
             <td>{{ machineset.autoscaler_min }}</td>
             <td>{{ machineset.autoscaler_max }}</td>
           </tr>

--- a/okd_camgi/templates/index.html
+++ b/okd_camgi/templates/index.html
@@ -32,6 +32,7 @@ table {
             <a href="#" v-on:click="changeContent('mcopods')" class="list-group-item list-group-item-action">Machine Config</a>
             <a href="#" v-on:click="changeContent('clusterautoscalers')" class="list-group-item list-group-item-action">ClusterAutoscalers</a>
             <a href="#" v-on:click="changeContent('machineautoscalers')" class="list-group-item list-group-item-action">MachineAutoscalers</a>
+            <a href="#" v-on:click="changeContent('machinesets')" class="list-group-item list-group-item-action">MachineSets</a>
             <a href="#" v-on:click="changeContent('machines')" class="list-group-item list-group-item-action">Machines
               {% if machines.notrunning|length > 0 %}<span class="badge bg-danger float-right">{{ machines.notrunning|length }}</span>{% endif %}
             </a>


### PR DESCRIPTION
this change adds a new navigation tab for machinesets which behaves in a similar manner as the other resource-based tabs.

also adds a column for the current replica count on machinesets participating in autoscaling.

closes #23 
closes #24 